### PR TITLE
Fixed bug "Wrong parameters for RuntimeException"

### DIFF
--- a/PostgresDb.php
+++ b/PostgresDb.php
@@ -227,7 +227,7 @@ class PostgresDb
         try {
             $stmt = $this->pdo()->prepare($this->_query);
         } catch (PDOException $e) {
-            throw new RuntimeException("Problem preparing query ($this->_query) " . $e->getMessage(), $e);
+            throw new RuntimeException("Problem preparing query ($this->_query) " . $e->getMessage(), $e->getCode());
         }
 
         return $stmt;


### PR DESCRIPTION
Fixed incorrect parameter passing in RuntimeException
Exception class constructor: Exception([ string $message = "" [, int $code = 0 [, Throwable $previous = NULL ]]])
Instead of the code, an Exception object was passed to the constructor